### PR TITLE
edit-table-cell-css-classes-41.3.1

### DIFF
--- a/packages/ckeditor5-html-support/src/datafilter.ts
+++ b/packages/ckeditor5-html-support/src/datafilter.ts
@@ -851,7 +851,10 @@ function matchAndConsumeAttributes(
 
 		// Verify and consume class names.
 		for ( const className of match.classes || [] ) {
-			if ( consumable.consume( viewElement, { classes: [ className ] } ) ) {
+			// Don't preserve classes on table cells because our attribute does that.
+			// If we do it here too then we create duplicates.
+			// @todo See if there is a better way to do this.
+			if ( consumable.consume( viewElement, { classes: [ className ] } ) && ![ 'td', 'th' ].includes( viewElement.name ) ) {
 				result.classes.push( className );
 			}
 		}

--- a/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellclassescommand.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellclassescommand.ts
@@ -1,0 +1,38 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module table/tablecellproperties/commands/tablecellverticalalignmentcommand
+ */
+
+import type { Editor } from 'ckeditor5/src/core.js';
+
+import TableCellPropertyCommand from './tablecellpropertycommand.js';
+
+/**
+ * The table cell classes command.
+ *
+ * The command is registered by the {@link module:table/tablecellproperties/tablecellpropertiesediting~TableCellPropertiesEditing} as
+ * the `'tableCellClasses'` editor command.
+ *
+ * To change the vertical text alignment of selected cells, execute the command:
+ *
+ * ```ts
+ * editor.execute( 'tableCellClasses', {
+ *   value: 'top'
+ * } );
+ * ```
+ */
+export default class TableCellClassesCommand extends TableCellPropertyCommand {
+	/**
+	 * Creates a new `TableCellClassesCommand` instance.
+	 *
+	 * @param editor An editor in which this command will be used.
+	 * @param defaultValue The default value for the "alignment" attribute.
+	 */
+	constructor( editor: Editor ) {
+		super( editor, 'tableCellClasses', '' );
+	}
+}

--- a/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.ts
@@ -30,6 +30,7 @@ import TableCellBorderColorCommand from './commands/tablecellbordercolorcommand.
 import TableCellBorderWidthCommand from './commands/tablecellborderwidthcommand.js';
 import { getNormalizedDefaultProperties } from '../utils/table-properties.js';
 import { enableProperty } from '../utils/common.js';
+import TableCellClassesCommand from './commands/tablecellclassescommand.js';
 
 const VALIGN_VALUES_REG_EXP = /^(top|middle|bottom)$/;
 const ALIGN_VALUES_REG_EXP = /^(left|center|right|justify)$/;
@@ -113,6 +114,11 @@ export default class TableCellPropertiesEditing extends Plugin {
 			defaultValue: defaultTableCellProperties.padding!
 		} );
 		editor.commands.add( 'tableCellPadding', new TableCellPaddingCommand( editor, defaultTableCellProperties.padding! ) );
+		enableCellClassesProperty( schema, conversion );
+		editor.commands.add(
+			'tableCellClasses',
+			new TableCellClassesCommand( editor )
+		);
 
 		editor.data.addStyleProcessorRules( addBackgroundRules );
 		enableProperty( schema, conversion, {
@@ -285,4 +291,23 @@ function enableVerticalAlignmentProperty( schema: Schema, conversion: Conversion
 				}
 			}
 		} );
+}
+
+function enableCellClassesProperty(
+	schema: Schema,
+	conversion: Conversion
+): void {
+	schema.extend( 'tableCell', {
+		allowAttributes: [ 'tableCellClasses' ]
+	} );
+
+	conversion.for( 'upcast' ).attributeToAttribute( {
+		view: 'class',
+		model: 'tableCellClasses'
+	} );
+
+	conversion.for( 'downcast' ).attributeToAttribute( {
+		model: 'tableCellClasses',
+		view: 'class'
+	} );
 }

--- a/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesui.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesui.ts
@@ -47,6 +47,7 @@ const propertyToCommandMap = {
 	height: 'tableCellHeight',
 	width: 'tableCellWidth',
 	padding: 'tableCellPadding',
+	classes: 'tableCellClasses',
 	backgroundColor: 'tableCellBackgroundColor',
 	horizontalAlignment: 'tableCellHorizontalAlignment',
 	verticalAlignment: 'tableCellVerticalAlignment'
@@ -254,6 +255,13 @@ export default class TableCellPropertiesUI extends Plugin {
 			validator: lengthFieldValidator
 		} ) );
 
+		view.on<ObservableChangeEvent<string>>( 'change:classes', this._getValidatedPropertyChangeCallback( {
+			viewField: view.classesInput,
+			commandName: 'tableCellClasses',
+			errorText: '',
+			validator: () => true
+		} ) );
+
 		view.on<ObservableChangeEvent<string>>( 'change:width', this._getValidatedPropertyChangeCallback( {
 			viewField: view.widthInput,
 			commandName: 'tableCellWidth',
@@ -430,7 +438,7 @@ export default class TableCellPropertiesUI extends Plugin {
 	 */
 	private _getValidatedPropertyChangeCallback(
 		options: {
-			commandName: `tableCell${ 'BorderColor' | 'BorderWidth' | 'Padding' | 'Width' | 'Height' | 'BackgroundColor' }`;
+			commandName: `tableCell${ 'BorderColor' | 'BorderWidth' | 'Padding' | 'Classes' | 'Width' | 'Height' | 'BackgroundColor' }`;
 			viewField: View & { errorText?: string | null };
 			validator: ( arg0: string ) => boolean;
 			errorText: string;

--- a/packages/ckeditor5-table/src/tablecellproperties/ui/tablecellpropertiesview.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/ui/tablecellpropertiesview.ts
@@ -103,6 +103,14 @@ export default class TableCellPropertiesView extends View {
 	public declare padding: string;
 
 	/**
+	 * The value of the cell classes.
+	 *
+	 * @observable
+	 * @default ''
+	 */
+	public declare classes: string;
+
+	/**
 	 * The value of the cell background color style.
 	 *
 	 * @observable
@@ -188,6 +196,11 @@ export default class TableCellPropertiesView extends View {
 	public readonly paddingInput: LabeledFieldView;
 
 	/**
+	 * An input that allows specifying the table cell CSS classes.
+	 */
+	public readonly classesInput: LabeledFieldView;
+
+	/**
 	 * An input that allows specifying the table cell width.
 	 */
 	public readonly widthInput: LabeledFieldView<FocusableView>;
@@ -244,6 +257,7 @@ export default class TableCellPropertiesView extends View {
 			borderWidth: '',
 			borderColor: '',
 			padding: '',
+			classes: '',
 			backgroundColor: '',
 			width: '',
 			height: '',
@@ -257,6 +271,7 @@ export default class TableCellPropertiesView extends View {
 		const { backgroundRowLabel, backgroundInput } = this._createBackgroundFields();
 		const { widthInput, operatorLabel, heightInput, dimensionsLabel } = this._createDimensionFields();
 		const { horizontalAlignmentToolbar, verticalAlignmentToolbar, alignmentLabel } = this._createAlignmentFields();
+		const { classesRowLabel, classesInput } = this._createClassesFields();
 
 		this.focusTracker = new FocusTracker();
 		this.keystrokes = new KeystrokeHandler();
@@ -266,6 +281,7 @@ export default class TableCellPropertiesView extends View {
 		this.borderColorInput = borderColorInput;
 		this.backgroundInput = backgroundInput;
 		this.paddingInput = this._createPaddingField();
+		this.classesInput = classesInput;
 		this.widthInput = widthInput;
 		this.heightInput = heightInput;
 		this.horizontalAlignmentToolbar = horizontalAlignmentToolbar;
@@ -296,6 +312,16 @@ export default class TableCellPropertiesView extends View {
 		// Form header.
 		this.children.add( new FormHeaderView( locale, {
 			label: this.t!( 'Cell properties' )
+		} ) );
+
+		// CSS classes row.
+		this.children.add( new FormRowView( locale, {
+			labelView: classesRowLabel,
+			children: [
+				classesRowLabel,
+				classesInput
+			],
+			class: 'ck-table-form__classes-row'
 		} ) );
 
 		// Border row.
@@ -707,6 +733,39 @@ export default class TableCellPropertiesView extends View {
 	/**
 	 * Creates the following form fields:
 	 *
+	 * * {@link #classesInput}.
+	 */
+	private _createClassesFields(): {
+		classesRowLabel: LabelView;
+		classesInput: LabeledFieldView;
+		} {
+		const locale = this.locale;
+		const t = this.t!;
+
+		const classesRowLabel = new LabelView( locale );
+		classesRowLabel.text = t( 'CSS classes' );
+
+		const classesInput = new LabeledFieldView( locale, createLabeledInputText );
+
+		classesInput.set( {
+			label: t( 'CSS classes' ),
+			class: 'ck-table-cell-properties-form__classes'
+		} );
+
+		classesInput.fieldView.bind( 'value' ).to( this, 'classes' );
+		classesInput.fieldView.on( 'input', () => {
+			this.classes = classesInput.fieldView.element!.value;
+		} );
+
+		return {
+			classesRowLabel,
+			classesInput
+		};
+	}
+
+	/**
+	 * Creates the following form fields:
+	 *
 	 * * {@link #horizontalAlignmentToolbar},
 	 * * {@link #verticalAlignmentToolbar}.
 	 */
@@ -789,7 +848,8 @@ export default class TableCellPropertiesView extends View {
 			this.borderWidthInput,
 			this.borderColorInput,
 			this.backgroundInput,
-			this.paddingInput
+			this.paddingInput,
+			this.classesInput
 		];
 
 		saveButtonView.set( {

--- a/packages/ckeditor5-table/theme/tableform.css
+++ b/packages/ckeditor5-table/theme/tableform.css
@@ -9,6 +9,10 @@
 			flex-wrap: wrap;
 		}
 
+		&.ck-table-form__classes-row {
+			flex-wrap: wrap;
+		}
+
 		&.ck-table-form__background-row {
 			flex-wrap: wrap;
 		}


### PR DESCRIPTION
This adds CSS classes to the table cell properties form.

It is for v41.3.1 as used in Drupal 10.3.0

Branch release-41.3.1 was branched from the v41.3.1 tag.